### PR TITLE
Add `-h` to tar

### DIFF
--- a/deploy-s6-overlay.sh
+++ b/deploy-s6-overlay.sh
@@ -180,7 +180,7 @@ fi
 
 # Install s6-overlay
 echo "[$APPNAME] Unpacking s6-overlay"
-tar -xzf /tmp/s6-overlay.tar.gz -C /
+tar --keep-directory-symlink -xzf /tmp/s6-overlay.tar.gz -C /
 
 # Test
 echo "[$APPNAME] Testing s6-overlay"

--- a/deploy-s6-overlay.sh
+++ b/deploy-s6-overlay.sh
@@ -180,7 +180,7 @@ fi
 
 # Install s6-overlay
 echo "[$APPNAME] Unpacking s6-overlay"
-tar --keep-directory-symlink -xzf /tmp/s6-overlay.tar.gz -C /
+tar -hxzf /tmp/s6-overlay.tar.gz -C /
 
 # Test
 echo "[$APPNAME] Testing s6-overlay"


### PR DESCRIPTION
Recent versions of Ubuntu symlink `/bin` to `/usr/bin`:

```
root@9b6eee25c0e1:/# ls -la
total 56
drwxr-xr-x  28 root root 4096 Aug 14 02:28 .
drwxr-xr-x  28 root root 4096 Aug 14 02:28 ..
-rwxr-xr-x   1 root root    0 Aug 14 02:28 .dockerenv
lrwxrwxrwx   1 root root    7 Jul 20 14:43 bin -> usr/bin
drwxr-xr-x   2 root root 4096 Apr 15 11:09 boot
drwxr-xr-x   5 root root  360 Aug 14 02:28 dev
drwxr-xr-x  32 root root 4096 Aug 14 02:28 etc
drwxr-xr-x   2 root root 4096 Apr 15 11:09 home
lrwxrwxrwx   1 root root    7 Jul 20 14:43 lib -> usr/lib
lrwxrwxrwx   1 root root    9 Jul 20 14:43 lib32 -> usr/lib32
lrwxrwxrwx   1 root root    9 Jul 20 14:43 lib64 -> usr/lib64
lrwxrwxrwx   1 root root   10 Jul 20 14:43 libx32 -> usr/libx32
drwxr-xr-x   2 root root 4096 Jul 20 14:43 media
drwxr-xr-x   2 root root 4096 Jul 20 14:43 mnt
drwxr-xr-x   2 root root 4096 Jul 20 14:43 opt
dr-xr-xr-x 625 root root    0 Aug 14 02:28 proc
drwx------   2 root root 4096 Jul 20 14:57 root
drwxr-xr-x   5 root root 4096 Jul 24 14:38 run
lrwxrwxrwx   1 root root    8 Jul 20 14:43 sbin -> usr/sbin
drwxr-xr-x   2 root root 4096 Jul 20 14:43 srv
dr-xr-xr-x  13 root root    0 Jun 10 07:09 sys
drwxrwxrwt   2 root root 4096 Jul 20 14:57 tmp
drwxr-xr-x  14 root root 4096 Jul 20 14:43 usr
drwxr-xr-x  13 root root 4096 Jul 20 14:57 var
```

When s6-overlay was being extracted with `tar`, this would clobber the `/bin` symlink with the directory in the archive, and cause issues.

This PR should hopefully fix that.
