### PR TITLE
Update deploy-s6-overlay-v3.sh

### DIFF
--- a/deploy-s6-overlay-v3.sh
+++ b/deploy-s6-overlay-v3.sh
@@ -6,7 +6,7 @@ echo "[$APPNAME] s6-overlay deployment started"
 
 # If the user has not specified a version to deploy, pin version v3.1.5.0
 if [ -z "$S6OVERLAY_VERSION" ]; then
-  S6OVERLAY_VERSION="v3.1.6.2"
+  S6OVERLAY_VERSION="v3.2.0.0"
 fi
 
 # Determine which downloader to use


### PR DESCRIPTION
Bump the default version of s6 overlay if none is specified in the ENV.